### PR TITLE
Fix diffusers version and update diffusers.models.autoencoder_tiny submodule name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages, setup
 _deps = [
     "torch",
     "xformers",
-    "diffusers>=0.32.1",
+    "diffusers>=0.31.0",
     "transformers",
     "accelerate",
     "fire",

--- a/setup.py
+++ b/setup.py
@@ -7,14 +7,14 @@ from setuptools import find_packages, setup
 _deps = [
     "torch",
     "xformers",
-    "diffusers>=0.30.1",
+    "diffusers>=0.32.1",
     "transformers",
     "accelerate",
     "fire",
     "omegaconf",
     "cuda-python",
-    "onnx==1.15.0",
-    "onnxruntime==1.16.3",
+    "onnx>=1.15.0",
+    "onnxruntime>=1.16.3",
     "protobuf>=3.20.2",
     "colored",
     "pywin32;sys_platform == 'win32'"

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ _deps = [
     "cuda-python",
     "onnx==1.15.0",
     "onnxruntime==1.16.3",
-    "protobuf==3.20.2",
+    "protobuf>=3.20.2",
     "colored",
     "pywin32;sys_platform == 'win32'"
 ]

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages, setup
 _deps = [
     "torch",
     "xformers",
-    "diffusers>=0.30.0",
+    "diffusers>=0.30.1",
     "transformers",
     "accelerate",
     "fire",

--- a/src/streamdiffusion/acceleration/tensorrt/engine.py
+++ b/src/streamdiffusion/acceleration/tensorrt/engine.py
@@ -1,7 +1,7 @@
 from typing import *
 
 import torch
-from diffusers.models.autoencoder_tiny import AutoencoderTinyOutput
+from diffusers.models.autoencoders.autoencoder_tiny import AutoencoderTinyOutput
 from diffusers.models.unet_2d_condition import UNet2DConditionOutput
 from diffusers.models.vae import DecoderOutput
 from polygraphy import cuda


### PR DESCRIPTION
Changes `diffusers` requirement from `>=0.30.0` to `>=0.32.1`
Loosens requirements for other packages
```
onnx>=1.15.0
onnxruntime>=1.16.3
protobuf>=3.20.2
```

This should be merged with  https://github.com/pschroedl/ComfyUI-StreamDiffusion/pull/11