### PR TITLE
[Issue] Missing ResolutionPicker

### DIFF
--- a/demo/realtime-img2img/frontend/src/routes/+page.svelte
+++ b/demo/realtime-img2img/frontend/src/routes/+page.svelte
@@ -9,7 +9,7 @@
   import ControlNetConfig from '$lib/components/ControlNetConfig.svelte';
   import PromptBlendingControl from '$lib/components/PromptBlendingControl.svelte';
   import SeedBlendingControl from '$lib/components/SeedBlendingControl.svelte';
-  import ResolutionPicker from '$lib/components/ResolutionPicker.svelte';
+  import ResolutionPicker from '$lib/components/ResolutionPicker.svelte'; // this is missing
   import Spinner from '$lib/icons/spinner.svelte';
   import Warning from '$lib/components/Warning.svelte';
   import { lcmLiveStatus, lcmLiveActions, LCMLiveStatus } from '$lib/lcmLive';


### PR DESCRIPTION
When trying to run the realtime-img2img, the ResolutionPicker component is defined but the file is missing.


Please close this pull request as its just an issue.